### PR TITLE
Corectare erori de build în frontend

### DIFF
--- a/frontend/src/pages/Auth/ResetPasswordPage.tsx
+++ b/frontend/src/pages/Auth/ResetPasswordPage.tsx
@@ -16,7 +16,7 @@ const ResetPasswordPage = () => {
   const [isSubmitted, setIsSubmitted] = useState(false);
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
-  const _navigate = useNavigate();
+  const navigate = useNavigate();
 
   // Verificăm validitatea token-ului la încărcarea paginii
   useEffect(() => {

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -6,6 +6,7 @@
     "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
+    "types": ["vitest/globals"],
 
     /* Bundler mode */
     "moduleResolution": "bundler",


### PR DESCRIPTION
Acest PR rezolvă erorile de build în frontend:

1. Adăugare `"types": ["vitest/globals"]` în `tsconfig.app.json` pentru a rezolva erorile legate de namespace-ul "vi"
2. Redenumire variabilă `_navigate` la `navigate` în `ResetPasswordPage.tsx` pentru a rezolva avertismentul de variabilă neutilizată

Aceste modificări permit build-ul cu succes al frontend-ului.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author